### PR TITLE
Fix race condition around `Sniffer.data`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,5 +4,3 @@ git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
 
 # Specify your gem's dependencies in sniffer.gemspec
 gemspec
-
-gem 'rubocop'

--- a/lib/sniffer.rb
+++ b/lib/sniffer.rb
@@ -8,7 +8,11 @@ require_relative "sniffer/data_item"
 
 # Sniffer allows to log http requests
 module Sniffer
+  @data = Set.new
+
   class << self
+    attr_reader :data
+
     def config
       @config ||= Config.new
       yield @config if block_given?
@@ -32,7 +36,7 @@ module Sniffer
     end
 
     def clear!
-      @data = []
+      data.clear
     end
 
     def reset!
@@ -40,14 +44,8 @@ module Sniffer
       clear!
     end
 
-    def data
-      @data ||= []
-    end
-
     def store(data_item)
-      return unless config.store
-      data
-      @data << data_item
+      @data.add(data_item) if config.store
     end
 
     def logger

--- a/spec/sniffer_spec.rb
+++ b/spec/sniffer_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Sniffer do
   end
 
   describe ".disable!" do
-    it 'disable sniffer' do
+    it 'disables sniffer' do
       Sniffer.config.enabled = true
       expect {
         Sniffer.disable!
@@ -17,7 +17,7 @@ RSpec.describe Sniffer do
   end
 
   describe ".enable!" do
-    it 'enable sniffer' do
+    it 'enables sniffer' do
       expect {
         Sniffer.enable!
       }.to change { Sniffer.enabled? }.to(true)
@@ -25,8 +25,8 @@ RSpec.describe Sniffer do
   end
 
   describe ".data" do
-    it "empty by default" do
-      expect(Sniffer.data).to eq([])
+    it "is empty by default" do
+      expect(Sniffer.data).to be_empty
     end
   end
 
@@ -35,32 +35,33 @@ RSpec.describe Sniffer do
       data_item = Sniffer::DataItem.new
       expect {
         Sniffer.store(data_item)
-      }.to change { Sniffer.data }.to([data_item])
+      }.to change { Sniffer.data.include?(data_item) }.to(true)
     end
   end
 
   context ".clear!" do
-    it 'clear data' do
+    it 'clears data' do
       Sniffer.store(Sniffer::DataItem.new)
+
       expect {
         Sniffer.clear!
-      }.to change { Sniffer.data }.to([])
+      }.to change { Sniffer.data.empty? }.to(true)
     end
   end
 
   context "config" do
-    it 'configurable' do
-      expect{
+    it 'is configurable' do
+      expect {
         Sniffer.config.enabled = true
-      }.to change{Sniffer.config.enabled}.from(false).to(true)
+      }.to change { Sniffer.config.enabled }.from(false).to(true)
     end
 
-    it 'configurable in block' do
-      expect{
+    it 'is configurable with block' do
+      expect {
         Sniffer.config do |c|
           c.enabled = true
         end
-      }.to change{Sniffer.config.enabled}.from(false).to(true)
+      }.to change { Sniffer.config.enabled }.from(false).to(true)
     end
   end
 end

--- a/spec/support/shared_examples_requests_spec.rb
+++ b/spec/support/shared_examples_requests_spec.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 RSpec.shared_examples "a sniffered" do |fldr|
+  let(:data_first_item) { Sniffer.data.first }
+
   it 'stores request if enabled', enabled: true do
     get_request
     expect(Sniffer.data).to_not be_empty
@@ -8,25 +10,23 @@ RSpec.shared_examples "a sniffered" do |fldr|
 
   it 'stores GET request correctly', enabled: true do
     get_request
-    data = Sniffer.data[0]
-    expect(data.to_h).to match_yaml_file("#{fldr}/get_response")
+    expect(data_first_item.to_h).to match_yaml_file("#{fldr}/get_response")
   end
 
   it 'stores GET request with dynamic params correctly', enabled: true do
     skip "Not implemented in adapter" unless respond_to?(:get_request_dynamic_params)
     get_request_dynamic_params
-    data = Sniffer.data[0]
-    expect(data.to_h).to match_yaml_file("#{fldr}/get_response_dynamic")
+    expect(data_first_item.to_h).to match_yaml_file("#{fldr}/get_response_dynamic")
   end
 
   it 'stores POST request correctly', enabled: true do
     post_request
-    expect(Sniffer.data[0].to_h).to match_yaml_file("#{fldr}/post_response")
+    expect(data_first_item.to_h).to match_yaml_file("#{fldr}/post_response")
   end
 
   it 'stores JSON correctly', enabled: true do
     post_json
-    expect(Sniffer.data[0].to_h).to match_yaml_file("#{fldr}/json_response")
+    expect(data_first_item.to_h).to match_yaml_file("#{fldr}/json_response")
   end
 
   it 'not stores request if disabled' do


### PR DESCRIPTION
Hi @aderyabin!

I've noticed two weak points in terms of thread-safety: memoization and unsafe `Array#<<`. Here is the fix with small code style improvements.