### PR TITLE
Refactor: move log method to sniffer class

### DIFF
--- a/lib/sniffer.rb
+++ b/lib/sniffer.rb
@@ -51,6 +51,18 @@ module Sniffer
       data.store(data_item) if config.store
     end
 
+    def log(data_item)
+      return unless logger && allowed_to_sniff?(data_item)
+      logger.log(config.severity, data_item.to_log.to_json)
+    end
+
+    def allowed_to_sniff?(data_item)
+      return true unless data_item.request
+      RequestPolicy.call(data_item.request)
+    end
+
+    private
+
     def logger
       config.logger
     end

--- a/lib/sniffer/adapters/curb_adapter.rb
+++ b/lib/sniffer/adapters/curb_adapter.rb
@@ -76,7 +76,7 @@ module Sniffer
                                                              body: body_str,
                                                              timing: timing)
 
-        data_item.log
+        Sniffer.log(data_item)
       end
     end
   end

--- a/lib/sniffer/adapters/ethon_adapter.rb
+++ b/lib/sniffer/adapters/ethon_adapter.rb
@@ -66,7 +66,7 @@ module Sniffer
                                                                   headers: hash_headers,
                                                                   body: @response_body,
                                                                   timing: bm)
-            @data_item.log
+            Sniffer.log(@data_item)
 
           end
 

--- a/lib/sniffer/adapters/eventmachine_adapter.rb
+++ b/lib/sniffer/adapters/eventmachine_adapter.rb
@@ -50,7 +50,7 @@ module Sniffer
         def on_body_data_with_sniffer(data)
           if Sniffer.enabled?
             @data_item.response.body = data
-            @data_item.log
+            Sniffer.log(@data_item)
           end
 
           on_body_data_without_sniffer(data)

--- a/lib/sniffer/adapters/excon_adapter.rb
+++ b/lib/sniffer/adapters/excon_adapter.rb
@@ -36,7 +36,7 @@ module Sniffer
                                                                body: @response.body,
                                                                timing: bm)
 
-          data_item.log
+          Sniffer.log(data_item)
         end
 
         @response

--- a/lib/sniffer/adapters/http_adapter.rb
+++ b/lib/sniffer/adapters/http_adapter.rb
@@ -55,7 +55,7 @@ module Sniffer
                                                                body: @res.body,
                                                                timing: bm)
 
-          data_item.log
+          Sniffer.log(data_item)
         end
 
         return @res unless opts.follow

--- a/lib/sniffer/adapters/httpclient_adapter.rb
+++ b/lib/sniffer/adapters/httpclient_adapter.rb
@@ -46,7 +46,7 @@ module Sniffer
 
           conn.push(res)
 
-          data_item.log
+          Sniffer.log(data_item)
         end
 
         raise retryable_response unless retryable_response.nil?

--- a/lib/sniffer/adapters/net_http_adapter.rb
+++ b/lib/sniffer/adapters/net_http_adapter.rb
@@ -38,7 +38,7 @@ module Sniffer
                                                                body: @response.body.to_s,
                                                                timing: bm)
 
-          data_item.log
+          Sniffer.log(data_item)
         end
 
         @response

--- a/lib/sniffer/adapters/patron_adapter.rb
+++ b/lib/sniffer/adapters/patron_adapter.rb
@@ -36,7 +36,7 @@ module Sniffer
                                                                body: @res.body.to_s,
                                                                timing: bm)
 
-          data_item.log
+          Sniffer.log(data_item)
         end
 
         @res

--- a/lib/sniffer/data.rb
+++ b/lib/sniffer/data.rb
@@ -4,7 +4,7 @@ module Sniffer
   # Data class stores the data and controls capacity
   class Data < Array
     def store(data_item)
-      return unless data_item.allowed_to_sniff?
+      return unless Sniffer.allowed_to_sniff?(data_item)
 
       if config.rotate?
         rotate(data_item)

--- a/lib/sniffer/data_item.rb
+++ b/lib/sniffer/data_item.rb
@@ -17,23 +17,9 @@ module Sniffer
       }
     end
 
-    def log
-      return unless Sniffer.logger && allowed_to_sniff?
-      Sniffer.logger.log(Sniffer.config.severity, to_json)
-    end
-
     def to_log
       return {} unless Sniffer.config.logger
       request.to_log.merge(response.to_log)
-    end
-
-    def to_json
-      to_log.to_json
-    end
-
-    def allowed_to_sniff?
-      return true unless request
-      RequestPolicy.call(request)
     end
 
     # Basic object for request and response objects

--- a/spec/sniffer/data_item_spec.rb
+++ b/spec/sniffer/data_item_spec.rb
@@ -18,10 +18,4 @@ RSpec.describe Sniffer::DataItem do
       expect(subject.to_log).to eq({})
     end
   end
-
-  context "#allowed_to_sniff?" do
-    it "returns true with empty data" do
-      expect(described_class.new.allowed_to_sniff?).to eq(true)
-    end
-  end
 end

--- a/spec/sniffer_spec.rb
+++ b/spec/sniffer_spec.rb
@@ -64,7 +64,13 @@ RSpec.describe Sniffer do
     end
   end
 
-  context ".clear!" do
+  describe ".allowed_to_sniff" do
+    it "returns true with empty data" do
+      expect(Sniffer.allowed_to_sniff?(Sniffer::DataItem.new)).to eq(true)
+    end
+  end
+
+  describe ".clear!" do
     it 'clears data' do
       Sniffer.store(Sniffer::DataItem.new)
 


### PR DESCRIPTION
Hi. I decided to split big PR https://github.com/aderyabin/sniffer/pull/35 for several smaller parts

Moved `log` method to sniffer class. It centralizes logic about loggin to sniffer class.
First little step to do a huge job.