### PR TITLE
README file actualized

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,8 +125,8 @@ Sniffer default options:
 
 ```ruby
 Sniffer.config do |c|
-  c.logger = Logger.new($stdout),
-  c.severity = Logger::Severity::DEBUG,
+  c.logger = Logger.new($stdout)
+  c.severity = Logger::Severity::DEBUG
   # HTTP options to log
   c.log = {
     request_url: true,
@@ -137,8 +137,8 @@ Sniffer.config do |c|
     response_headers: true,
     response_body: true,
     timing: true
-  },
-  c.store =  true, # save requests/responses to Sniffer.data
+  }
+  c.store =  true # save requests/responses to Sniffer.data
   c.enabled = false  # Sniffer disabled by default
   c.url_whitelist = nil
   c.url_blacklist = nil


### PR DESCRIPTION
Seems that config section is outdated and it took some time to debug the issue after copy/paste this to existing project.

Description of `c.log` data structure also conflicts with the actual code, ex. line lib/sniffer/data_item.rb:70 where `log_settings["request_url"]` should be `log_settings[:request_url]` etc.

I solved this by updating actual lib code instead documentation, cause I found new hash declaration preferable. I could make additional PR on readme or actual code respectively. Preferred way is up to you.

Cheers