### PR TITLE
Bump anyway_config

### DIFF
--- a/sniffer.gemspec
+++ b/sniffer.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   end
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "anyway_config", ">= 1.0"
+  spec.add_dependency "anyway_config", ">= 2.0"
   spec.add_dependency "active_attr", ">= 0.10.2"
 
   spec.add_development_dependency "bundler", "~> 2"

--- a/sniffer.gemspec
+++ b/sniffer.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "anyway_config", ">= 2.0"
   spec.add_dependency "dry-initializer", "~> 3"
-  
+
   spec.add_development_dependency "bundler", "~> 2"
   spec.add_development_dependency "rake", ">= 12.3.3"
   spec.add_development_dependency "rspec", "~> 3.0"


### PR DESCRIPTION
Bump `anyway_config` dependency to fix Ruby 2.7 deprecation warnings:

https://github.com/aderyabin/sniffer/issues/60
