### PR TITLE
Fix ethon typhoeus exception handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+* Fixed `NoMethodError` on Ethon/Typhoeus network failures by [@blaze182](https://github.com/blaze182)
+* Adjusted host and query parsing for Ethon/Typhoeus
+
 ## 0.5.0 (May 6, 2022) ##
 
 * Added prepend of all adapters by [@nate-at-gusto](https://github.com/nate-at-gusto)

--- a/lib/sniffer/adapters/ethon_adapter.rb
+++ b/lib/sniffer/adapters/ethon_adapter.rb
@@ -18,7 +18,7 @@ module Sniffer
           return unless Sniffer.enabled?
 
           @data_item = Sniffer::DataItem.new
-          uri = URI("http://#{url}")
+          uri = URI(url.start_with?(%r{https?://}) ? url : "http://#{url}")
 
           @data_item.request = Sniffer::DataItem::Request.new(host: uri.host,
                                                               method: action_name.upcase,
@@ -50,7 +50,7 @@ module Sniffer
           end
 
           if Sniffer.enabled?
-            uri = URI("http://#{@url}")
+            uri = URI(url.start_with?(%r{https?://}) ? url : "http://#{@url}")
             query = uri.path
             query += "?#{uri.query}" if uri.query
             @data_item.request.query = query

--- a/lib/sniffer/adapters/ethon_adapter.rb
+++ b/lib/sniffer/adapters/ethon_adapter.rb
@@ -55,9 +55,8 @@ module Sniffer
             query += "?#{uri.query}" if uri.query
             @data_item.request.query = query
 
-            status = @response_headers.scan(%r{HTTP/... (\d{3})}).flatten[0].to_i
-            hash_headers = @response_headers
-                           .split(/\r?\n/)[1..-1]
+            status = response_code
+            hash_headers = (@response_headers.split(/\r?\n/)[1..-1] || [])
                            .each_with_object({}) do |item, res|
               k, v = item.split(": ")
               res[k] = v

--- a/spec/sniffer/adapters/curb_adapter_spec.rb
+++ b/spec/sniffer/adapters/curb_adapter_spec.rb
@@ -17,6 +17,10 @@ RSpec.describe Curl do
     end
   end
 
+  def unresolved_request
+    Curl::Easy.http_get('http://localh0st:45678/')
+  end
+
   it 'logs', enabled: true do
     logger = double
     Sniffer.config.logger = logger

--- a/spec/sniffer/adapters/ethon_adapter_spec.rb
+++ b/spec/sniffer/adapters/ethon_adapter_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Ethon do
   let(:headers) { { "accept-encoding" => "gzip;q=1.0,deflate;q=0.6,identity;q=0.3", "accept" => "*/*", "user-agent" => "Ruby", "host" => "localhost:4567" } }
   let(:get_request) do
     easy = Ethon::Easy.new
-    easy.http_request("localhost:4567/?lang=ruby&author=matz", :get, headers: headers)
+    easy.http_request("http://localhost:4567/?lang=ruby&author=matz", :get, headers: headers)
     easy.perform
   end
 

--- a/spec/sniffer/adapters/ethon_adapter_spec.rb
+++ b/spec/sniffer/adapters/ethon_adapter_spec.rb
@@ -30,6 +30,12 @@ RSpec.describe Ethon do
     easy.perform
   end
 
+  def unresolved_request
+    easy = Ethon::Easy.new
+    easy.http_request('localh0st:45678', :get)
+    easy.perform
+  end
+
   it 'logs', enabled: true do
     logger = double
     Sniffer.config.logger = logger

--- a/spec/sniffer/adapters/eventmachine_adapter_spec.rb
+++ b/spec/sniffer/adapters/eventmachine_adapter_spec.rb
@@ -35,6 +35,15 @@ RSpec.describe EventMachine do
     }
   end
 
+  def unresolved_request
+    EventMachine.run {
+      http = EventMachine::HttpRequest.new("http://localh0st:45678").get
+      http.errback {
+        EventMachine.stop
+      }
+    }
+  end
+
   it 'logs', enabled: true do
     logger = double
     Sniffer.config.logger = logger

--- a/spec/sniffer/adapters/http_adapter_spec.rb
+++ b/spec/sniffer/adapters/http_adapter_spec.rb
@@ -9,6 +9,10 @@ RSpec.describe HTTP do
   let(:post_request) { HTTP.post('http://localhost:4567/data?lang=ruby', body: "author=Matz") }
   let(:post_json) { HTTP.post('http://localhost:4567/json', json: { 'lang' => 'Ruby', 'author' => 'Matz' }) }
 
+  def unresolved_request
+    HTTP.get('http://localh0st:45678/')
+  end
+
   it 'logs', enabled: true do
     logger = double
     Sniffer.config.logger = logger

--- a/spec/sniffer/adapters/httpclient_adapter_spec.rb
+++ b/spec/sniffer/adapters/httpclient_adapter_spec.rb
@@ -23,6 +23,10 @@ RSpec.describe HTTPClient do
     JSONClient.new.post(uri, 'lang' => 'Ruby', 'author' => 'Matz')
   end
 
+  def unresolved_request
+    client.get(URI('http://localh0st:45678/'))
+  end
+
   it 'logs', enabled: true do
     logger = double
     Sniffer.config.logger = logger

--- a/spec/sniffer/adapters/net_http_adapter_spec.rb
+++ b/spec/sniffer/adapters/net_http_adapter_spec.rb
@@ -31,6 +31,11 @@ RSpec.describe Net::HTTP do
     http.request(request)
   end
 
+  def unresolved_request
+    uri = URI.parse('http://localh0st:45678/')
+    Net::HTTP.get(uri)
+  end
+
   it 'logs', enabled: true do
     logger = double
     Sniffer.config.logger = logger

--- a/spec/sniffer/adapters/patron_adapter_spec.rb
+++ b/spec/sniffer/adapters/patron_adapter_spec.rb
@@ -10,6 +10,10 @@ RSpec.describe Patron::Session do
   let(:post_request) { session.post('/data?lang=ruby', "author=Matz") }
   let(:post_json) { session.post('/json', { 'lang' => 'Ruby', 'author' => 'Matz' }.to_json, "Content-Type" => "application/json; charset=UTF-8") }
 
+  def unresolved_request
+    Patron::Session.new(base_url: 'http://localhost:45678').get('/')
+  end
+
   it 'logs', enabled: true do
     logger = double
     Sniffer.config.logger = logger

--- a/spec/sniffer/adapters/typhoeus_adapter_spec.rb
+++ b/spec/sniffer/adapters/typhoeus_adapter_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 
 RSpec.describe Typhoeus do
   let(:headers) { { "accept-encoding" => "gzip;q=1.0,deflate;q=0.6,identity;q=0.3", "accept" => "*/*", "user-agent" => "Ruby", "host" => "localhost:4567" } }
-  let(:get_request) { Typhoeus::Request.new('localhost:4567/?lang=ruby&author=matz', method: :get, headers: headers).run }
+  let(:get_request) { Typhoeus::Request.new('http://localhost:4567/?lang=ruby&author=matz', method: :get, headers: headers).run }
   let(:get_request_dynamic_params) do
     Typhoeus::Request.new("localhost:4567/?lang=ruby",
                           method: :get,

--- a/spec/sniffer/adapters/typhoeus_adapter_spec.rb
+++ b/spec/sniffer/adapters/typhoeus_adapter_spec.rb
@@ -20,6 +20,10 @@ RSpec.describe Typhoeus do
                           headers: { 'Content-Type' => "application/json" }).run
   end
 
+  def unresolved_request
+    Typhoeus::Request.new('localhost:45678').run
+  end
+
   it 'logs', enabled: true do
     logger = double
     Sniffer.config.logger = logger

--- a/spec/support/shared_examples_requests_spec.rb
+++ b/spec/support/shared_examples_requests_spec.rb
@@ -40,6 +40,22 @@ RSpec.shared_examples "a sniffered" do |fldr|
     expect(Sniffer.data).to be_empty
   end
 
+  it 'preserves the original behavior for unresolved requests', enabled: true do
+    skip "Not implemented in adapter" unless respond_to?(:unresolved_request)
+
+    def error_class(enabled: true)
+      Sniffer.disable! unless enabled
+      unresolved_request
+      nil
+    rescue StandardError => e
+      e.class
+    ensure
+      Sniffer.enable!
+    end
+
+    expect(error_class).to eq(error_class(enabled: false))
+  end
+
   context 'with url_whitelist', enabled: true do
     it 'stores data with matched url' do
       Sniffer.config.url_whitelist = /localhost:4567/


### PR DESCRIPTION
<!--
  First of all, thanks for contributing!

  If it's a typo fix or minor documentation update feel free to skip the rest of this template!
-->

Hi everyone and thanks for the fabulous gem.

## What is the purpose of this pull request?

This PR improves integration with Ethon and Typhoeus libraries. Sniffer is currently interfering with the behaviour of these libs on network errors, and is not parsing urls prepended with `http(s)://` correctly.

<!--
  If it's a bug fix, then link it to the issue, for example:

  Fixes #xxx
-->

## What changes did you make? (overview)

#### NoMethodError

Sniffer is currently crashing with `NoMethodError: undefined method 'each_with_object' for nil:NilClass` if Ethon/Typhoeus request fails with any kind of network errors (host not found, timeout, etc.). However, the original behaviour of those libraries is to not raise any exceptions on `.perform` / `.run` respectively.

The reason is `@response_headers` is empty and is returning nil after split:

https://github.com/aderyabin/sniffer/blob/cdd52e4a89a1fa6f40295e3253898c8e2c3209d5/lib/sniffer/adapters/ethon_adapter.rb#L59-L64

In order to prevent interfering with original libraries' behaviour, I propose another shared spec example which runs `unresolved_request` twice (hence the method instead of `let`) with and without Sniffer, and compares the error outcomes.

#### URL parsing

`URI("http://#{url}")` should become `URI(url.start_with?(%r{https?://}) ? url : "http://#{url}")`, otherwise we have a shift in Sniffer's host and query (i.e. host equals "https", query is "//localhost:4567/?author=Matz"). Ethon and Typhoeus support both formats of the urls.

## Checklist

- [x] I've added tests for this change
- [x] I've added a Changelog entry
- [ ] I've updated a documentation
