### PR TITLE
because you broke the compatibility by using a cancer called rubocop

### DIFF
--- a/sniffer.gemspec
+++ b/sniffer.gemspec
@@ -14,6 +14,8 @@ Gem::Specification.new do |spec|
   spec.homepage      = "http://github.com/aderyabin/sniffer"
   spec.license       = "MIT"
 
+  spec.required_ruby_version = ">= 2.5"
+  
   spec.files         = `git ls-files -z`.split("\x0").reject do |f|
     f.match(%r{^(test|spec|features)/})
   end


### PR DESCRIPTION
https://github.com/aderyabin/sniffer/commit/989decb621cf0a2ba1c8107ddc91bd387f968cad#r90484803