### PR TITLE
Ethon hostname fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.5.1 (Oct 12, 2023) ##
+
+* Fixed hostname handling for `ethon`-based libs by [@nullder](https://github.com/nulldef)
+
 ## 0.5.0 (May 6, 2022) ##
 
 * Added prepend of all adapters by [@nate-at-gusto](https://github.com/nate-at-gusto)

--- a/lib/sniffer/adapters/ethon_adapter.rb
+++ b/lib/sniffer/adapters/ethon_adapter.rb
@@ -18,7 +18,9 @@ module Sniffer
           return unless Sniffer.enabled?
 
           @data_item = Sniffer::DataItem.new
-          uri = URI("http://#{url}")
+
+          url = url.start_with?("http") ? url : "http://#{url}"
+          uri = URI(url)
 
           @data_item.request = Sniffer::DataItem::Request.new(host: uri.host,
                                                               method: action_name.upcase,
@@ -50,7 +52,9 @@ module Sniffer
           end
 
           if Sniffer.enabled?
-            uri = URI("http://#{@url}")
+            url = @url.start_with?("http") ? @url : "http://#{@url}"
+            uri = URI(url)
+
             query = uri.path
             query += "?#{uri.query}" if uri.query
             @data_item.request.query = query

--- a/lib/sniffer/data_item.rb
+++ b/lib/sniffer/data_item.rb
@@ -83,7 +83,7 @@ module Sniffer
 
           if log_settings["request_headers"]
             headers.each do |(k, v)|
-              hash[:"rq_#{k.to_s.tr("-", '_').downcase}"] = v
+              hash[:"rq_#{k.to_s.tr('-', '_').downcase}"] = v
             end
           end
 
@@ -119,7 +119,7 @@ module Sniffer
 
           if log_settings["response_headers"]
             headers.each do |(k, v)|
-              hash[:"rs_#{k.to_s.tr("-", '_').downcase}"] = v
+              hash[:"rs_#{k.to_s.tr('-', '_').downcase}"] = v
             end
           end
 

--- a/lib/sniffer/version.rb
+++ b/lib/sniffer/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Sniffer
-  VERSION = "0.5.0"
+  VERSION = "0.5.1"
 end

--- a/spec/sniffer/adapters/ethon_adapter_spec.rb
+++ b/spec/sniffer/adapters/ethon_adapter_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Ethon do
   let(:headers) { { "accept-encoding" => "gzip;q=1.0,deflate;q=0.6,identity;q=0.3", "accept" => "*/*", "user-agent" => "Ruby", "host" => "localhost:4567" } }
   let(:get_request) do
     easy = Ethon::Easy.new
-    easy.http_request("localhost:4567/?lang=ruby&author=matz", :get, headers: headers)
+    easy.http_request("http://localhost:4567/?lang=ruby&author=matz", :get, headers: headers)
     easy.perform
   end
 


### PR DESCRIPTION
## What is the purpose of this pull request?

Fix the incorrect hostname handling for the ethon-based libs.

For instance, calling `GET https://demo.url/test`

Before: `{ host: "https", method: "GET" }`
After:  `{ host: "demo.url", method: "GET" }`

## What changes did you make?

Added a check if the URL already starts with `http`

## Is there anything you'd like reviewers to focus on?

nope 🤷‍♂️

## Checklist

- [x] I've added tests for this change
- [x] I've added a Changelog entry
