### PR TITLE
Restrict configuration sources to ENV and YAML

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -12,6 +12,8 @@ AllCops:
     - "*.gemspec"
   DisplayCopNames: true
   StyleGuideCopsOnly: false
+  SuggestExtensions: false
+  NewCops: disable
 
 Naming/AccessorMethodName:
   Enabled: false

--- a/lib/sniffer/config.rb
+++ b/lib/sniffer/config.rb
@@ -9,6 +9,10 @@ module Sniffer
   class Config < Anyway::Config
     config_name :sniffer
 
+    # Only load configuration from static sources; prevent from trying to load
+    # from network sources, such as Doppler, to avoid recursion errors
+    self.configuration_sources = %i[env yml] if respond_to?(:configuration_sources)
+
     attr_config logger: Logger.new($stdout),
                 severity: Logger::Severity::DEBUG,
                 log: {

--- a/lib/sniffer/data_item.rb
+++ b/lib/sniffer/data_item.rb
@@ -83,7 +83,7 @@ module Sniffer
 
           if log_settings["request_headers"]
             headers.each do |(k, v)|
-              hash[:"rq_#{k.to_s.tr("-", '_').downcase}"] = v
+              hash[:"rq_#{k.to_s.tr('-', '_').downcase}"] = v
             end
           end
 
@@ -119,7 +119,7 @@ module Sniffer
 
           if log_settings["response_headers"]
             headers.each do |(k, v)|
-              hash[:"rs_#{k.to_s.tr("-", '_').downcase}"] = v
+              hash[:"rs_#{k.to_s.tr('-', '_').downcase}"] = v
             end
           end
 


### PR DESCRIPTION
## Context

Recently, we found an issue with the combination of Sniffer, Anyway Config, and Doppler: a max call stack error occurs when we have an HTTP-backed configuration source available for Anyway Config.

Sniffer tries to load the configuration, and while it's still being loaded, we perform an HTTP request, which in its turn again tries to initializes the configuration—and the loop continues 'till it hits the max stack error.

## Solution

We can limit the configuration sources for Sniffer to ENV and YAML. Those are safe to use (well, unless someone adds an HTTP call to YAML via ERB 😁).

Since we never mentioned that Sniffer can be configured in _any_ way, keeping just ENV and YAML should be a good compromise. 

## Alternative solutions

I also considered making the config initialization two-phased: first, allocation and saving the `@config` variable, then doing the actual load (once). It's a bit more tricky because it would require to deal with the Anyway internals (we invoke `#load` right in the `#initialize`—not good) and handle the in-the-middle-of-loading state. Still worth exploring though.

## Misc changes

Fixed some RuboCop issues.

## Backporting

For those hitting the issue and waiting for a new release, the following snippet should help (make sure you use `anyway_config` >= 2.8.0):

```ruby
require "sniffer/config"

Sniffer::Config.configuration_sources = [:env, :yml]
``` 
